### PR TITLE
Update getdata() to exit when query complete

### DIFF
--- a/query.js
+++ b/query.js
@@ -42,6 +42,10 @@ module.exports = function (args, opts) {
     handleErrors(res, body)
     if (opts.progress) doProgress(body)
     var items = body.message.items
+    if ( items.length === 0 ) {
+      console.log('Completed query.\n')
+      process.exit()
+    }
     n += items.length
     return items
   }


### PR DESCRIPTION
My `open-retractions` didn't after completing an `npm run update`. 

The CrossRef API page keeps returning cursors, beyond the final page (e.g., [this page](
http://api.crossref.org/works?filter=is-update:true,update-type:comment,update-type:corrected-article,update-type:correction,update-type:Correction,update-type:correspondence,update-type:corrigendum,update-type:Corrigendum,update-type:err,update-type:erratum,update-type:Erratum,update-type:expression_of_concern,update-type:expression-of-concern,update-type:note-discuss,update-type:publisher-note,update-type:removal,update-type:retraction,update-type:Retraction,update-type:retration,update-type:withdrawal,from-pub-date:2019-10-01&cursor=AoJwoeG03e4CPw1odHRwOi8vZHguZG9pLm9yZy8xMC4xMDE2L2oud25ldS4yMDE5LjA5LjAwMQ%3D%3D&rows=1000), if the link doesn't expire). It seems like this made the program go into an infinite cursor follow. 

By adding this `if` clause, the query seemed to exit properly (from my limited testing).


