### PR TITLE
Fix query.js query constructor

### DIFF
--- a/query.js
+++ b/query.js
@@ -4,7 +4,7 @@ var pumpify = require('pumpify')
 var xtend = require('xtend')
 var ProgressBar = require('progress')
 
-var API_URL = 'http://api.crossref.org/v1/works'
+var API_URL = 'https://api.crossref.org/works'
 
 module.exports = function (args, opts) {
   if (args.filter && args.filter instanceof Array) {
@@ -15,8 +15,9 @@ module.exports = function (args, opts) {
   var progress
   var query = xtend({
     cursor: '*',
-    rows: (args.limit && args.limit < 1000) ? args.limit : 1000
-  }, args)
+    rows: (args.limit && args.limit < 1000) ? args.limit : 1000,
+    filter: args.filter
+  })
 
   if (query.limit) {
     delete query.limit


### PR DESCRIPTION
When trying to update the `open-retractions` database as a preparation for setting up a cron job, I found out I could not actually update the database (error below). I updated the query constructor to the proposed change, after which I could run the update again.

Note: I updated the `API_URL` to be up-to-date with the current API link.

```bash
chjh@node open-retractions % node update/daily.js 
Getting CrossRef since 2019-12-01
Querying CrossRef with: {
  '0': '2',
  '1': '0',
  '2': '1',
  '3': '9',
  '4': '-',
  '5': '1',
  '6': '2',
  '7': '-',
  '8': '0',
  '9': '1',
  cursor: '*',
  rows: 1000,
  filter: 'is-update:true,update-type:comment,update-type:corrected-article,update-type:correction,update-type:Correction,update-type:correspondence,update-type:corrigendum,update-type:Corrigendum,update-type:err,update-type:erratum,update-type:Erratum,update-type:expression_of_concern,update-type:expression-of-concern,update-type:note-discuss,update-type:publisher-note,update-type:removal,update-type:retraction,update-type:Retraction,update-type:retration,update-type:withdrawal'
}
Received an error from the CrossRef API:
Parameter 0 specified but there is no such parameter available on any route
Parameter 4 specified but there is no such parameter available on any route
Parameter 7 specified but there is no such parameter available on any route
Parameter 1 specified but there is no such parameter available on any route
Parameter 8 specified but there is no such parameter available on any route
Parameter 9 specified but there is no such parameter available on any route
Parameter 2 specified but there is no such parameter available on any route
Parameter 5 specified but there is no such parameter available on any route
Parameter 3 specified but there is no such parameter available on any route
Parameter 6 specified but there is no such parameter available on any route
```